### PR TITLE
Logmet

### DIFF
--- a/49-haproxy.conf
+++ b/49-haproxy.conf
@@ -1,0 +1,6 @@
+# Create an additional socket in haproxy's chroot in order to allow logging via
+# /dev/log to chroot'ed HAProxy processes
+$AddUnixListenSocket /var/lib/haproxy/dev/log
+
+# Send HAProxy messages to a dedicated logfile
+if $programname startswith 'haproxy' then /var/log/haproxy.log

--- a/50-default.conf
+++ b/50-default.conf
@@ -1,0 +1,55 @@
+#  Default rules for rsyslog.
+#
+#			For more information see rsyslog.conf(5) and /etc/rsyslog.conf
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*			/var/log/auth.log
+*.*;auth,authpriv.none		-/var/log/syslog
+#cron.*				/var/log/cron.log
+#daemon.*			-/var/log/daemon.log
+kern.*				-/var/log/kern.log
+#lpr.*				-/var/log/lpr.log
+mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+mail.err			/var/log/mail.err
+
+#
+# Logging for INN news system.
+#
+news.crit			/var/log/news/news.crit
+news.err			/var/log/news/news.err
+news.notice			-/var/log/news/news.notice
+
+#
+# Some "catch-all" log files.
+#
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg                                :omusrmsg:*
+
+#
+# I like to have messages displayed on the console, but only on a virtual
+# console I usually leave idle.
+#
+#daemon,mail.*;\
+#	news.=crit;news.=err;news.=notice;\
+#	*.=debug;*.=info;\
+#	*.=notice;*.=warn	/dev/tty8

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,20 @@ FROM ubuntu:trusty
 
 MAINTAINER Ben Smith (benjsmi@us.ibm.com)
 
+ADD https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_linux_amd64 /opt/forwarder
+ADD http://game-on.org:8081/logstashneeds.tar /opt/logstashneeds.tar
+
 RUN cd /opt ; echo deb http://archive.ubuntu.com/ubuntu trusty-backports main universe | \
     tee /etc/apt/sources.list.d/backports.list ; apt-get update ; apt-get install -y haproxy -t trusty-backports ; \
-    mkdir -p /run/haproxy/
+    mkdir -p /run/haproxy/ ; apt-get install -y rsyslog ; cd /opt ; chmod +x ./forwarder ; \
+    tar xvzf logstashneeds.tar ; rm logstashneeds.tar
 
+COPY ./rsyslog.conf /etc/rsyslog.conf
+COPY ./49-haproxy.conf /etc/rsyslog.d/49-haproxy.conf
+COPY ./50-default.conf /etc/rsyslog.d/50-haproxy.conf
 COPY ./proxy.pem /etc/ssl/proxy.pem
 COPY ./startup.sh /opt/startup.sh
+COPY ./forwarder.conf /opt/forwarder.conf
 
 COPY ./haproxy.cfg /etc/haproxy/haproxy.cfg
 

--- a/forwarder.conf
+++ b/forwarder.conf
@@ -1,0 +1,37 @@
+{
+  # The network section covers network configuration :)
+  "network": {
+    # A list of downstream servers listening for our messages.
+    # logstash-forwarder will pick one at random and only switch if
+    # the selected one appears to be dead or unresponsive
+    "servers": [ "game-on.org:5043" ],
+
+    # The path to your client ssl certificate (optional)
+    "ssl certificate": "./logstash-forwarder.crt",
+    # The path to your client ssl key (optional)
+    "ssl key": "./logstash-forwarder.key",
+
+    # The path to your trusted ssl CA file. This is used
+    # to authenticate your downstream server.
+    "ssl ca": "./logstash-forwarder.crt",
+
+    # Network timeout in seconds. This is most important for
+    # logstash-forwarder determining whether to stop waiting for an
+    # acknowledgement from the downstream server. If an timeout is reached,
+    # logstash-forwarder will assume the connection or server is bad and
+    # will connect to a server chosen at random from the servers list.
+    "timeout": 15
+  },
+
+  # The list of files configurations
+  "files": [
+    {
+      "paths": [
+        "/var/log/haproxy.log"
+      ],
+      "fields": { "type": "syslog",
+      			  "source": "haproxy"
+      			}
+    }
+  ]
+}

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,11 +1,12 @@
 global
-	log PLACEHOLDER_LOGHOST	local0
-	log PLACEHOLDER_LOGHOST	local1 notice
+	log 127.0.0.1	local0
+	log 127.0.0.1	local1 notice
 	chroot /var/lib/haproxy
 	stats socket /run/haproxy/admin.sock mode 660 level admin
 	stats timeout 30s
 	user haproxy
 	group haproxy
+	daemon
 
 	ssl-default-bind-ciphers kEECDH+aRSA+AES:kRSA+AES:+AES256:RC4-SHA:!kEDH:!LOW:!EXP:!MD5:!aNULL:!eNULL
 

--- a/idsBuild.sh
+++ b/idsBuild.sh
@@ -5,7 +5,7 @@
 #
 
 echo Informing slack...
-curl -X 'POST' --silent --data-binary '{"text":"A new build for the proxy has started."}' $WEBHOOK > /dev/null
+#curl -X 'POST' --silent --data-binary '{"text":"A new build for the proxy has started."}' $WEBHOOK > /dev/null
 mkdir dockercfg ; cd dockercfg
 echo Downloading Docker requirements..
 wget http://$BUILD_DOCKER_HOST:8081/dockerneeds.tar -q

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,61 @@
+#  /etc/rsyslog.conf	Configuration file for rsyslog.
+#
+#			For more information see
+#			/usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
+#
+#  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
+
+
+#################
+#### MODULES ####
+#################
+
+$ModLoad imuxsock # provides support for local system logging
+#$ModLoad imklog   # provides kernel logging support
+#$ModLoad immark  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+$ModLoad imudp
+$UDPServerRun 514
+
+# provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+# Enable non-kernel facility klog messages
+#$KLogPermitNonKernelFacility on
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# Filter duplicated messages
+$RepeatedMsgReduction on
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+

--- a/startup.sh
+++ b/startup.sh
@@ -3,6 +3,9 @@
 echo Replacing password in...
 sed -i s/PLACEHOLDER_PASSWORD/$ADMIN_PASSWORD/g /etc/haproxy/haproxy.cfg
 sed -i s/PLACEHOLDER_DOCKERHOST/$PROXY_DOCKER_HOST/g /etc/haproxy/haproxy.cfg
-sed -i s/PLACEHOLDER_LOGHOST/$LOGGING_DOCKER_HOST/g /etc/haproxy/haproxy.cfg
-echo Starting haproxy-- foreground mode.
+echo Starting rsyslog...
+service rsyslog start
+echo Starting haproxy-- background mode.
 haproxy -f /etc/haproxy/haproxy.cfg
+echo Starting the log forwarder...
+cd /opt ; ./forwarder --config ./forwarder.conf


### PR DESCRIPTION
Have to install rsyslogd and properly configure it to dump haproxy's logs to a file that the Logstash Forwarder can then forward on to our logstash so that it can be grokked and then sent to Logmet.
