### PR TITLE
Update haproxy to 1.6, redirect /swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:trusty
+FROM haproxy:1.6
 
 MAINTAINER Ben Smith (benjsmi@us.ibm.com)
 
-RUN cd /opt ; echo deb http://archive.ubuntu.com/ubuntu trusty-backports main universe | \
-    tee /etc/apt/sources.list.d/backports.list ; apt-get update ; apt-get install -y wget ; apt-get install -y haproxy -t trusty-backports ; \
-    mkdir -p /run/haproxy/
+RUN apt-get update && apt-get install -y wget --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/local/etc/haproxy /etc/
+RUN mkdir /run/haproxy
 
 COPY ./proxy.pem /etc/ssl/proxy.pem
 COPY ./startup.sh /opt/startup.sh
@@ -14,4 +14,5 @@ COPY ./haproxy-dev.cfg /etc/haproxy/haproxy-dev.cfg
 
 EXPOSE 80 443 1936
 
-CMD ["/opt/startup.sh"]
+ENTRYPOINT ["/opt/startup.sh"]
+CMD [""]

--- a/haproxy-dev.cfg
+++ b/haproxy-dev.cfg
@@ -1,9 +1,9 @@
 global
-	chroot /var/lib/haproxy
+	#chroot /var/lib/haproxy
+    #user haproxy
+	#group haproxy
 	stats socket /run/haproxy/admin.sock mode 660 level admin
 	stats timeout 30s
-	user haproxy
-	group haproxy
 
 	ssl-default-bind-ciphers kEECDH+aRSA+AES:kRSA+AES:+AES256:RC4-SHA:!kEDH:!LOW:!EXP:!MD5:!aNULL:!eNULL
 
@@ -132,7 +132,6 @@ backend dockerui
   server dockerui1 192.168.99.100:9000 check
   acl auth_ok http_auth(admins)
   http-request auth unless auth_ok
-  reqrep ^([^\ ]*\ /)docker[/]?(.*) \1\2
 
 backend logstash-lumberjack
   mode tcp
@@ -142,10 +141,13 @@ backend logstash-lumberjack
 
 backend swagger
   mode http
-  option httpchk HEAD /swagger/ HTTP/1.1\r\nHost:localhost
+  acl swagger_root path -i /swagger
+  redirect location /swagger/ if swagger_root
+  option httpchk HEAD / HTTP/1.1\r\nHost:localhost
   option httplog
   balance roundrobin
   server swagger1 192.168.99.100:8081 check
+
 
 listen stats
     bind *:1936 ssl crt /etc/ssl/proxy.pem

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,10 +1,10 @@
 global
 	log PLACEHOLDER_LOGHOST	syslog
-	chroot /var/lib/haproxy
+	#chroot /var/lib/haproxy
 	stats socket /run/haproxy/admin.sock mode 660 level admin
 	stats timeout 30s
-	user haproxy
-	group haproxy
+	#user haproxy
+	#group haproxy
 
 	ssl-default-bind-ciphers kEECDH+aRSA+AES:kRSA+AES:+AES256:RC4-SHA:!kEDH:!LOW:!EXP:!MD5:!aNULL:!eNULL
 
@@ -151,7 +151,10 @@ backend logstash-lumberjack
 
 backend swagger
   mode http
-  option httpchk HEAD /swagger/ HTTP/1.1\r\nHost:localhost
+  acl swagger_root path -i /swagger
+  redirect location /swagger/ if swagger_root
+
+  option httpchk HEAD / HTTP/1.1\r\nHost:localhost
   option httplog
   balance roundrobin
   server swagger1 PLACEHOLDER_DOCKERHOST:8081 check

--- a/startup.sh
+++ b/startup.sh
@@ -18,4 +18,3 @@ else
   sed -i s/PLACEHOLDER_PASSWORD/$ADMIN_PASSWORD/g /etc/haproxy/haproxy-dev.cfg
   haproxy -f /etc/haproxy/haproxy-dev.cfg
 fi
-


### PR DESCRIPTION
Update haproxy to v1.6, 
write intelligible rules about redirecting /swagger to /swagger/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-proxy/5)

<!-- Reviewable:end -->
