### PR TITLE
Use generated cert from go-setup

### DIFF
--- a/haproxy-dev.cfg
+++ b/haproxy-dev.cfg
@@ -33,7 +33,7 @@ frontend logstash-lumberjack
   default_backend logstash-lumberjack
 
 frontend frontend-ssl
-  bind *:443 ssl crt /etc/ssl/proxy.pem
+  bind *:443 ssl crt /keystore/proxy.pem
   mode http
   option httplog
 


### PR DESCRIPTION
Previously used ssl cert checked in, now uses cert generated
as part of go-setup, via the shared /keystore volume mapped
into this container via docker compose (local dev only change)
Signed-off-by: Ozzy Osborne ozzy@ca.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-proxy/14)

<!-- Reviewable:end -->
